### PR TITLE
feat: Add Hive, Hadoop, and PySpark icons to Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ src="https://img.shields.io/github/followers/mahakg290399?logo=github&style=for-
 <a href="https://www.mongodb.com/" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/mongodb-colored.svg" width="36" height="36" alt="MongoDB" /></a>
 <a href="https://www.mysql.com/" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/mysql-colored.svg" width="36" height="36" alt="MySQL" /></a>
 <a href="https://flask.palletsprojects.com/en/2.0.x/" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/flask-colored.svg" width="36" height="36" alt="Flask" /></a>
+<a href="https://hive.apache.org/" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/hive-colored.svg" width="36" height="36" alt="Hive" /></a>
+<a href="https://hadoop.apache.org/" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/hadoop-colored.svg" width="36" height="36" alt="Hadoop" /></a>
+<a href="https://spark.apache.org/docs/latest/api/python/" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/danielcranney/readme-generator/main/public/icons/skills/pyspark-colored.svg" width="36" height="36" alt="PySpark" /></a>
 </p>
 
 


### PR DESCRIPTION
Adds new icons for Hive, Hadoop, and PySpark to the "Skills" section of the README.md file. The icons are sourced from `danielcranney/readme-generator` and link to the respective technology's official website. This change enhances your profile by showcasing a broader range of technical skills.